### PR TITLE
fix: add missing OP_CHECKMULTISIG to p2ms locking script

### DIFF
--- a/decoding/p2ms.mdx
+++ b/decoding/p2ms.mdx
@@ -70,6 +70,7 @@ M
 <PubKey2>
 <PubKeyN>
 N
+OP_CHECKMULTISIG
   `}
     language="text"
     showLineNumbers={true}


### PR DESCRIPTION
This PR adds the missing `OP_CHECKMULTISIG` instruction to the locking script example on the P2MS page.