### PR TITLE
fix(musig): html code rendering

### DIFF
--- a/decoding/musig.mdx
+++ b/decoding/musig.mdx
@@ -438,10 +438,9 @@ Where:
 ### Final Signature
 
 The final aggregate signature is:
+<code>(R<span className="text-xs align-sub">agg</span>, s<span className="text-xs align-sub">agg</span>)</code>
 
-`(R<span className="text-xs align-sub">agg</span>, s<span className="text-xs align-sub">agg</span>)`
-
-This pair can be verified using `P<span className="text-xs align-sub">agg</span>` and the message `m`.
+This pair can be verified using <code>P<span className="text-xs align-sub">agg</span></code> and the message `m`.
 
 ---
 


### PR DESCRIPTION
This PR resolves an issue with HTML code rendering on the MuSig page, where backticks were preventing the code from being interpreted correctly.