### PR TITLE
refactor: change references to bitcoin-topics to decoding-bitcoin

### DIFF
--- a/authors/default.mdx
+++ b/authors/default.mdx
@@ -1,7 +1,7 @@
 ---
 name: BDP
 nym: default
-avatar: /bitcoin-topics/static/images/authors/bdp.jpeg
+avatar: /decoding-bitcoin/static/images/authors/bdp.jpeg
 twitter: https://x.com/Bitcoin_Devs
 github: https://github.com/bitcoin-dev-project/bitcoin-dev-project
 ---

--- a/decoding/bitcoin-history.mdx
+++ b/decoding/bitcoin-history.mdx
@@ -31,7 +31,7 @@ order: 102
             ],
             media: {
                 type: "image",
-                src: "/bitcoin-topics/static/images/topics/bitcoin-history/step1-dark.png",
+                src: "/decoding-bitcoin/static/images/topics/bitcoin-history/step1-dark.png",
                 alt: "Satoshi starts working on Bitcoin"
             }
         },
@@ -59,7 +59,7 @@ order: 102
             ],
             media: {
                 type: "image",
-                src: "/bitcoin-topics/static/images/topics/bitcoin-history/whitepaper.png",
+                src: "/decoding-bitcoin/static/images/topics/bitcoin-history/whitepaper.png",
                 alt: "Satoshi starts working on Bitcoin"
             }
         },
@@ -83,7 +83,7 @@ order: 102
             ],
             media: {
                 type: "image",
-                src: "/bitcoin-topics/static/images/topics/bitcoin-history/step8.png",
+                src: "/decoding-bitcoin/static/images/topics/bitcoin-history/step8.png",
                 alt: "Genesis block"
             }
         },
@@ -204,7 +204,7 @@ order: 102
             ],
             media: {
                 type: "image",
-                src: "/bitcoin-topics/static/images/topics/bitcoin-history/step7.png",
+                src: "/decoding-bitcoin/static/images/topics/bitcoin-history/step7.png",
                 alt: "Genesis block"
             }
         },
@@ -296,7 +296,7 @@ order: 102
             ],
             media: {
                 type: "image",
-                src: "/bitcoin-topics/static/images/topics/bitcoin-history/step6.png",
+                src: "/decoding-bitcoin/static/images/topics/bitcoin-history/step6.png",
                 alt: "Genesis block"
             }
         },

--- a/decoding/bitcoin-opcodes.mdx
+++ b/decoding/bitcoin-opcodes.mdx
@@ -8,7 +8,7 @@ layout: TopicBanner
 order: 2
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/bitcoin-opcodes-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/bitcoin-opcodes-thumbnail.webp"
     ]
 parent: overview
 ---
@@ -26,14 +26,14 @@ The visualization below includes an explanation of the most commonly used opcode
 
 <div className="dark:hidden w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/opcode-category.gif"
+        src="/decoding-bitcoin/static/images/topics/overview/opcode-category.gif"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/opcode-category.gif"
+        src="/decoding-bitcoin/static/images/topics/overview/opcode-category.gif"
         width="100%"
         height="auto"
     />

--- a/decoding/compact-size.mdx
+++ b/decoding/compact-size.mdx
@@ -9,7 +9,7 @@ order: 2
 icon: "FaHashtag"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/taproot-roadmap-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/taproot-roadmap-thumbnail.webp"
     ]
 parent: "technical-foundation"
 ---

--- a/decoding/endianness.mdx
+++ b/decoding/endianness.mdx
@@ -9,7 +9,7 @@ order: 1
 icon: "FaHashtag"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/endianness.png"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/endianness.png"
     ]
 parent: "technical-foundation"
 ---
@@ -24,14 +24,14 @@ Similarly, computers have two ways to store data:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/technical-foundation/communication-endianness.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/technical-foundation/communication-endianness.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/technical-foundation/communication-endianness.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/technical-foundation/communication-endianness.svg"
         width="100%"
         height="auto"
     />
@@ -50,14 +50,14 @@ Suppose we want to store the number **12345678** (hexadecimal: `0x00BC614E`) in 
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/technical-foundation/bigendian.jpg"
+        src="/decoding-bitcoin/static/images/topics/transactions/technical-foundation/bigendian.jpg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/technical-foundation/bigendian.jpg"
+        src="/decoding-bitcoin/static/images/topics/transactions/technical-foundation/bigendian.jpg"
         width="100%"
         height="auto"
     />
@@ -85,14 +85,14 @@ Using the same number **12345678** (`0x00BC614E`), here's how it looks in **litt
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/technical-foundation/littleendian.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/technical-foundation/littleendian.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/technical-foundation/littleendian.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/technical-foundation/littleendian.png"
         width="100%"
         height="auto"
     />

--- a/decoding/fee-calculation.mdx
+++ b/decoding/fee-calculation.mdx
@@ -7,7 +7,7 @@ category: Transactions
 layout: TopicBanner
 order: 306
 icon: "FaClipboardList"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/transaction-module/fees-thumbnail-feecalculation.jpg"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/fees-thumbnail-feecalculation.jpg"]
 children: ["transaction-weight", "blocksize-blockweight", "fee-rate", "rbf"]
 ---
 
@@ -37,14 +37,14 @@ Let's calculate the fee for the following <a href="https://mempool.space/tx/c27c
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_0_temp.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_0_temp.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_0_temp.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_0_temp.png"
         width="100%"
         height="auto"
     />
@@ -77,14 +77,14 @@ Miners receive two types of rewards for securing the network:
 
 <div className="dark:hidden w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_1.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_1.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_1.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_1.svg"
         width="100%"
         height="auto"
     />
@@ -105,14 +105,14 @@ For now, understand that:
 
 <div className="dark:hidden w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_2.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_2.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_2.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_2.svg"
         width="100%"
         height="auto"
     />
@@ -149,14 +149,14 @@ Let's say you have a transaction that's been sitting in the mempool for hours be
 
 <div className="dark:hidden w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_3.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_3.svg"
         width="80%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_3.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_3.svg"
         width="80%"
         height="auto"
     />

--- a/decoding/fee-rate.mdx
+++ b/decoding/fee-rate.mdx
@@ -7,7 +7,7 @@ category: Transactions
 layout: TopicBanner
 order: 2
 icon: "FaClipboardList"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/musig-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/musig-thumbnail.webp"]
 parent: "fee-calculation"
 ---
 

--- a/decoding/implement-OP_ADD-OP_HASH160.mdx
+++ b/decoding/implement-OP_ADD-OP_HASH160.mdx
@@ -9,7 +9,7 @@ order: 4
 project: true
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/project-stack-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/project-stack-thumbnail.webp"
     ]
 parent: project
 ---

--- a/decoding/implement-OP_CHECKSIG.mdx
+++ b/decoding/implement-OP_CHECKSIG.mdx
@@ -9,7 +9,7 @@ order: 5
 project: true
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/project-stack-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/project-stack-thumbnail.webp"
     ]
 parent: project
 ---

--- a/decoding/implement-basic-stack.mdx
+++ b/decoding/implement-basic-stack.mdx
@@ -9,7 +9,7 @@ order: 2
 project: true
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/project-stack-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/project-stack-thumbnail.webp"
     ]
 parent: project
 ---

--- a/decoding/inputs-inputcount.mdx
+++ b/decoding/inputs-inputcount.mdx
@@ -7,7 +7,7 @@ category: Transactions
 layout: TopicBanner
 order: 3
 icon: "FaClipboardList"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/transaction-module/fees-thumbnail-inputcount.jpg"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/fees-thumbnail-inputcount.jpg"]
 parent: "transaction-structure"
 ---
 
@@ -27,14 +27,14 @@ Let's examine this real transaction:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_10_inputcount.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_10_inputcount.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_10_inputcount.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_10_inputcount.png"
         width="100%"
         height="auto"
     />

--- a/decoding/inputs-output-index.mdx
+++ b/decoding/inputs-output-index.mdx
@@ -9,7 +9,7 @@ order: 4
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/fees-thumbnail-vout.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/fees-thumbnail-vout.jpg"
     ]
 parent: "transaction-structure"
 ---
@@ -22,14 +22,14 @@ Let's examine our transaction to understand this better:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_12_vout.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_12_vout.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_12_vout.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_12_vout.png"
         width="100%"
         height="auto"
     />

--- a/decoding/inputs-prev-txid.mdx
+++ b/decoding/inputs-prev-txid.mdx
@@ -9,7 +9,7 @@ order: 4
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/fees-thumbnail-prevtxid.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/fees-thumbnail-prevtxid.jpg"
     ]
 parent: "transaction-structure"
 ---
@@ -24,14 +24,14 @@ Let's examine our transaction to understand this better:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_11_txid.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_11_txid.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_11_txid.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_11_txid.png"
         width="100%"
         height="auto"
     />

--- a/decoding/inputs-scriptsig.mdx
+++ b/decoding/inputs-scriptsig.mdx
@@ -9,7 +9,7 @@ order: 6
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-thumbnail-scriptsig.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-thumbnail-scriptsig.jpg"
     ]
 parent: "transaction-structure"
 ---
@@ -20,14 +20,14 @@ The ScriptSig is a variable-length field in transaction inputs that provides the
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-scriptsig.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-scriptsig.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-scriptsig.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-scriptsig.png"
         width="100%"
         height="auto"
     />

--- a/decoding/inputs-scriptsigsize.mdx
+++ b/decoding/inputs-scriptsigsize.mdx
@@ -9,7 +9,7 @@ order: 5
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/fees-thumbnail-scriptsig-size.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/fees-thumbnail-scriptsig-size.jpg"
     ]
 parent: "transaction-structure"
 ---
@@ -22,14 +22,14 @@ Let's examine our transaction to understand this better:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_13_scriptsigsize.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_13_scriptsigsize.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_13_scriptsigsize.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_13_scriptsigsize.png"
         width="100%"
         height="auto"
     />

--- a/decoding/inputs-sequence.mdx
+++ b/decoding/inputs-sequence.mdx
@@ -7,7 +7,7 @@ category: Transactions
 layout: TopicBanner
 order: 6
 icon: "FaClipboardList"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-thumbnail-sequence.jpg"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-thumbnail-sequence.jpg"]
 parent: "transaction-structure"
 ---
 
@@ -20,14 +20,14 @@ Let's examine our transaction to understand this better:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-sequence.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-sequence.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-sequence.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-sequence.png"
         width="100%"
         height="auto"
     />

--- a/decoding/introduction-taproot.mdx
+++ b/decoding/introduction-taproot.mdx
@@ -7,7 +7,7 @@ category: Taproot
 layout: TopicBanner
 order: 506
 icon: "FaHashtag"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/musig-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/musig-thumbnail.webp"]
 ---
 
 (coming soon)

--- a/decoding/locking-unlocking.mdx
+++ b/decoding/locking-unlocking.mdx
@@ -8,7 +8,7 @@ layout: TopicBanner
 order: 3
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/locking-unlocking-scripts-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/locking-unlocking-scripts-thumbnail.webp"
     ]
 parent: overview
 ---
@@ -21,14 +21,14 @@ A locking script, also known as a ScriptPubKey, is placed on every output you cr
 
 <div className="dark:hidden w-full">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/lock-script.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/lock-script.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/dark-lock-script.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/dark-lock-script.svg"
         width="100%"
         height="auto"
     />
@@ -50,14 +50,14 @@ An unlocking script, also known as a ScriptSig or Witness, is provided for every
 
 <div className="dark:hidden w-full">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/unlock-script.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/unlock-script.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/dark-unlock-script.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/dark-unlock-script.svg"
         width="100%"
         height="auto"
     />
@@ -83,14 +83,14 @@ If the unlocking script successfully satisfies the conditions set by the locking
 
 <div className="dark:hidden w-full">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/lock-unlock.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/lock-unlock.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/dark-lock-unlock.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/dark-lock-unlock.svg"
         width="100%"
         height="auto"
     />

--- a/decoding/locktime.mdx
+++ b/decoding/locktime.mdx
@@ -9,7 +9,7 @@ order: 11
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-thumbnail-locktime.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-thumbnail-locktime.jpg"
     ]
 parent: "transaction-structure"
 ---
@@ -22,14 +22,14 @@ Let's examine our transaction to understand this better:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-locktime.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-locktime.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-locktime.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-locktime.png"
         width="100%"
         height="auto"
     />

--- a/decoding/marker-flag.mdx
+++ b/decoding/marker-flag.mdx
@@ -9,7 +9,7 @@ order: 2
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-marker-flag.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-marker-flag.webp"
     ]
 parent: "transaction-structure"
 ---

--- a/decoding/musig.mdx
+++ b/decoding/musig.mdx
@@ -7,7 +7,7 @@ category: Taproot
 layout: TopicBanner
 order: 505
 icon: "FaHashtag"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/musig-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/musig-thumbnail.webp"]
 ---
 
 By the end of this article, we want Alice, Bob, and Carol to sign a transaction using MuSig.
@@ -24,13 +24,13 @@ MuSig is simply a protocol for aggregating public keys and signatures.
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/musig-1.webp"
+        src="/decoding-bitcoin/static/images/topics/taproot/musig-1.webp"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/musig-1.webp"
+        src="/decoding-bitcoin/static/images/topics/taproot/musig-1.webp"
         height="auto"
     />
 </div>
@@ -45,14 +45,14 @@ The reasons we use MuSig are:
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/musig-2.webp"
+        src="/decoding-bitcoin/static/images/topics/taproot/musig-2.webp"
         width="120%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/musig-2.webp"
+        src="/decoding-bitcoin/static/images/topics/taproot/musig-2.webp"
         width="120%"
         height="auto"
     />
@@ -81,13 +81,13 @@ Some of these steps require rounds of communication between participants:
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/musig-3.webp"
+        src="/decoding-bitcoin/static/images/topics/taproot/musig-3.webp"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/musig-3.webp"
+        src="/decoding-bitcoin/static/images/topics/taproot/musig-3.webp"
         height="auto"
     />
 </div>
@@ -106,13 +106,13 @@ However, this approach is vulnerable to a **key cancellation attack.**
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/musig-4.webp"
+        src="/decoding-bitcoin/static/images/topics/taproot/musig-4.webp"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/musig-4.webp"
+        src="/decoding-bitcoin/static/images/topics/taproot/musig-4.webp"
         height="auto"
     />
 </div>
@@ -171,13 +171,13 @@ Here’s how we construct individual public keys and the aggregated public key:
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/musig-5.webp"
+        src="/decoding-bitcoin/static/images/topics/taproot/musig-5.webp"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/musig-5.webp"
+        src="/decoding-bitcoin/static/images/topics/taproot/musig-5.webp"
         height="auto"
     />
 </div>

--- a/decoding/network-propagation.mdx
+++ b/decoding/network-propagation.mdx
@@ -7,7 +7,7 @@ category: Transactions
 layout: TopicBanner
 order: 308
 icon: "FaClipboardList"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/musig-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/musig-thumbnail.webp"]
 ---
 
 (Coming Soon)

--- a/decoding/newsletter.mdx
+++ b/decoding/newsletter.mdx
@@ -22,7 +22,7 @@ We summarize every post and then summarize the summaries so that every thread su
 <div className="w-full sm:w-2/6">
 
 <MinimalVideoPlayer 
-    src="/bitcoin-topics/static/images/topics/newsletter.webp" 
+    src="/decoding-bitcoin/static/images/topics/newsletter.webp" 
     autoPlay={false} 
 />
 </div>

--- a/decoding/nonce-reuse-attack.mdx
+++ b/decoding/nonce-reuse-attack.mdx
@@ -9,7 +9,7 @@ order: 504
 icon: "FaHashtag"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/nonce-reuse-attack-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/nonce-reuse-attack-thumbnail.webp"
     ]
 ---
 
@@ -23,13 +23,13 @@ Let's start by breaking down the Schnorr signature equation to see how this happ
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/nonce-reuse-attack-1-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/nonce-reuse-attack-1-light.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/nonce-reuse-attack-1.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/nonce-reuse-attack-1.svg"
         height="auto"
     />
 </div>
@@ -40,13 +40,13 @@ Imagine you want to sign two separate transactions but mistakenly use the same n
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/nonce-reuse-attack-2-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/nonce-reuse-attack-2-light.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/nonce-reuse-attack-2.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/nonce-reuse-attack-2.svg"
         height="auto"
     />
 </div>
@@ -77,13 +77,13 @@ Since all these values are publicly accessible (S1, S2, and the hashed transacti
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/nonce-reuse-attack-3-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/nonce-reuse-attack-3-light.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/nonce-reuse-attack-3.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/nonce-reuse-attack-3.svg"
         height="auto"
     />
 </div>

--- a/decoding/number-decoding-encoding.mdx
+++ b/decoding/number-decoding-encoding.mdx
@@ -9,7 +9,7 @@ order: 3
 project: true
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/project-stack-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/project-stack-thumbnail.webp"
     ]
 parent: project
 ---

--- a/decoding/outputs-amount.mdx
+++ b/decoding/outputs-amount.mdx
@@ -9,7 +9,7 @@ order: 8
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-thumbnail-amount.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-thumbnail-amount.jpg"
     ]
 parent: "transaction-structure"
 ---
@@ -22,14 +22,14 @@ Let's examine our transaction to understand this better:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-amount.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-amount.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-amount.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-amount.png"
         width="100%"
         height="auto"
     />

--- a/decoding/outputs-outputcount.mdx
+++ b/decoding/outputs-outputcount.mdx
@@ -7,7 +7,7 @@ category: Transactions
 layout: TopicBanner
 order: 7
 icon: "FaClipboardList"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-thumbnail-outputcount.jpg"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-thumbnail-outputcount.jpg"]
 parent: "transaction-structure"
 ---
 
@@ -17,14 +17,14 @@ The number of outputs in a transaction is stored as a variable-length integer (v
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-outputcount.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-outputcount.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-outputcount.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-outputcount.png"
         width="100%"
         height="auto"
     />

--- a/decoding/outputs-scriptpubkey-size.mdx
+++ b/decoding/outputs-scriptpubkey-size.mdx
@@ -9,7 +9,7 @@ order: 9
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-thumbnail-scriptpubkeysize.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-thumbnail-scriptpubkeysize.jpg"
     ]
 parent: "transaction-structure"
 ---
@@ -22,14 +22,14 @@ Let's examine a real transaction to understand this better:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-scriptpksize.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-scriptpksize.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-scriptpksize.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-scriptpksize.png"
         width="100%"
         height="auto"
     />

--- a/decoding/outputs-scriptpubkey.mdx
+++ b/decoding/outputs-scriptpubkey.mdx
@@ -9,7 +9,7 @@ order: 10
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-thumbnail-scriptpubkey.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-thumbnail-scriptpubkey.jpg"
     ]
 parent: "transaction-structure"
 ---
@@ -22,14 +22,14 @@ Let's examine a real transaction output's ScriptPubKey:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-scriptpubkey.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-scriptpubkey.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/tx-scriptpubkey.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/tx-scriptpubkey.png"
         width="100%"
         height="auto"
     />

--- a/decoding/overview.mdx
+++ b/decoding/overview.mdx
@@ -8,7 +8,7 @@ layout: TopicBanner
 order: 400
 icon: "FaClipboardList"
 images:
-    ["/bitcoin-topics/static/images/topics/thumbnails/overview-thumbnail.webp"]
+    ["/decoding-bitcoin/static/images/topics/thumbnails/overview-thumbnail.webp"]
 children:
     - stack
     - bitcoin-opcodes
@@ -29,7 +29,7 @@ Key features of bitcoin Script include:
 
 <div className="dark:hidden w-full">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/overview.gif"
+        src="/decoding-bitcoin/static/images/topics/overview/overview.gif"
         width="100%"
         height="auto"
         className="rounded-lg"
@@ -37,7 +37,7 @@ Key features of bitcoin Script include:
 </div>
 <div className="hidden dark:block w-full">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/overview.gif"
+        src="/decoding-bitcoin/static/images/topics/overview/overview.gif"
         width="100%"
         height="auto"
         className="rounded-lg"

--- a/decoding/p2ms-exercise-1.mdx
+++ b/decoding/p2ms-exercise-1.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 1
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2ms-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2ms-thumbnail.webp"]
 parent: p2ms
 ---
 

--- a/decoding/p2ms-exercise-2.mdx
+++ b/decoding/p2ms-exercise-2.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 2
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2ms-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2ms-thumbnail.webp"]
 parent: p2ms
 ---
 

--- a/decoding/p2ms.mdx
+++ b/decoding/p2ms.mdx
@@ -7,7 +7,7 @@ category: Scripts
 layout: TopicBanner
 order: 404
 icon: "FaUsers"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2ms-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2ms-thumbnail.webp"]
 children:
     - p2ms-exercise-1
     - p2ms-exercise-2
@@ -139,7 +139,7 @@ Click on **Input 1** of the transaction to view the ScriptSig created to unlock 
     but it may require more computational steps, which will slow down the
     verification process.
     <img
-        src="/bitcoin-topics/static/images/topics/overview/p2ms/p2ms_order_signature.png"
+        src="/decoding-bitcoin/static/images/topics/overview/p2ms/p2ms_order_signature.png"
         alt="P2MS Signature Order Efficiency"
     />
     Both sequences are valid in a this 1-of-3 multisig. The left sequence is

--- a/decoding/p2pk-exercise1.mdx
+++ b/decoding/p2pk-exercise1.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 2
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2pk-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2pk-thumbnail.webp"]
 parent: p2pk
 ---
 

--- a/decoding/p2pk-exercise2.mdx
+++ b/decoding/p2pk-exercise2.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 3
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2pk-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2pk-thumbnail.webp"]
 parent: p2pk
 ---
 

--- a/decoding/p2pk-exercise3.mdx
+++ b/decoding/p2pk-exercise3.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 4
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2pk-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2pk-thumbnail.webp"]
 parent: p2pk
 ---
 
@@ -14,7 +14,7 @@ parent: p2pk
 
 In this exercise, you'll implement a function to convert a P2PK (Pay-to-Public-Key) ScriptPubKey from its hexadecimal representation to ASM format.
 
-![P2PK Problems](/bitcoin-topics/static/images/topics/p2pk/asm_hex.png)
+![P2PK Problems](/decoding-bitcoin/static/images/topics/p2pk/asm_hex.png)
 
 1. Implement the `decodeP2PKScriptPubKey` function in the code editor below.
 2. The function should convert the input hex string to a Buffer.

--- a/decoding/p2pk-problems.mdx
+++ b/decoding/p2pk-problems.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 1
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2pk-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2pk-thumbnail.webp"]
 parent: p2pk
 ---
 
@@ -37,7 +37,7 @@ Below are some issues associated with P2PK.
         <li>Compressed: 33 bytes (66 hex characters)</li>
       </ul>
     </div>
-    <img src="/bitcoin-topics/static/images/topics/p2pk/p2pk-problem1.png" alt="Long Public Keys" className="w-full h-auto mt-auto" />
+    <img src="/decoding-bitcoin/static/images/topics/p2pk/p2pk-problem1.png" alt="Long Public Keys" className="w-full h-auto mt-auto" />
   </div>
 
 {" "}
@@ -76,7 +76,7 @@ Below are some issues associated with P2PK.
         </ul>
     </div>
     <img
-        src="/bitcoin-topics/static/images/topics/p2pk/p2pk-problem2.png"
+        src="/decoding-bitcoin/static/images/topics/p2pk/p2pk-problem2.png"
         alt="Larger UTXOs"
         className="w-full h-auto mt-auto"
     />
@@ -100,7 +100,7 @@ Below are some issues associated with P2PK.
         <li>Increases attack surface</li>
       </ul>
     </div>
-    <img src="/bitcoin-topics/static/images/topics/p2pk/p2pk-problem3.png" alt="Security Vulnerability" className="w-full h-auto mt-auto" />
+    <img src="/decoding-bitcoin/static/images/topics/p2pk/p2pk-problem3.png" alt="Security Vulnerability" className="w-full h-auto mt-auto" />
   </div>
 </div>
 

--- a/decoding/p2pk.mdx
+++ b/decoding/p2pk.mdx
@@ -7,7 +7,7 @@ category: Scripts
 layout: TopicBanner
 order: 401
 icon: "FaKey"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2pk-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2pk-thumbnail.webp"]
 children:
     - p2pk-problems
     - p2pk-exercise1
@@ -41,14 +41,14 @@ The ability to lock and unlock coins is the mechanism by which we transfer bitco
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/unlock-script.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/unlock-script.svg"
         width="80%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/dark-unlock-script.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/dark-unlock-script.svg"
         width="80%"
         height="auto"
     />
@@ -57,7 +57,7 @@ The ability to lock and unlock coins is the mechanism by which we transfer bitco
 #### 1- Locking (ScriptPubKey):
 
 <SvgDisplay
-    src="/bitcoin-topics/static/images/topics/p2pk/spk.svg"
+    src="/decoding-bitcoin/static/images/topics/p2pk/spk.svg"
     width="44%"
     height="auto"
 />
@@ -106,7 +106,7 @@ their public keys are smaller => smaller transaction on the network => save bloc
 #### 2- Unlocking (ScriptSig)
 
 <SvgDisplay
-    src="/bitcoin-topics/static/images/topics/p2pk/scriptsig.svg"
+    src="/decoding-bitcoin/static/images/topics/p2pk/scriptsig.svg"
     width="44%"
     height="auto"
 />

--- a/decoding/p2pkh-exercise1.mdx
+++ b/decoding/p2pkh-exercise1.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 1
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2pkh-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2pkh-thumbnail.webp"]
 parent: p2pkh
 ---
 

--- a/decoding/p2pkh-exercise2.mdx
+++ b/decoding/p2pkh-exercise2.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 2
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2pkh-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2pkh-thumbnail.webp"]
 parent: p2pkh
 ---
 

--- a/decoding/p2pkh.mdx
+++ b/decoding/p2pkh.mdx
@@ -7,7 +7,7 @@ category: Scripts
 layout: TopicBanner
 order: 402
 icon: "FaHashtag"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2pkh-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2pkh-thumbnail.webp"]
 children:
     - p2pkh-exercise1
     - p2pkh-exercise2
@@ -67,7 +67,7 @@ Have you ever heard about the guy who bought two <a href="https://bitcointalk.or
 P2PKH is similar to [P2PK](/decoding/4-p2pk) transactions, except that the bitcoin is locked to the **_hash_** of the public key rather than the public key itself.
 
 <SvgDisplay
-    src="/bitcoin-topics/static/images/topics/p2pkh/p2pkh.svg"
+    src="/decoding-bitcoin/static/images/topics/p2pkh/p2pkh.svg"
     width="100%"
     height="auto"
 />

--- a/decoding/p2sh-exercise-1.mdx
+++ b/decoding/p2sh-exercise-1.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 1
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2sh-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2sh-thumbnail.webp"]
 parent: p2sh
 ---
 

--- a/decoding/p2sh-exercise-2.mdx
+++ b/decoding/p2sh-exercise-2.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 2
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2sh-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2sh-thumbnail.webp"]
 parent: p2sh
 ---
 

--- a/decoding/p2sh.mdx
+++ b/decoding/p2sh.mdx
@@ -7,7 +7,7 @@ category: Scripts
 layout: TopicBanner
 order: 403
 icon: "FaFileCode"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/p2sh-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/p2sh-thumbnail.webp"]
 children:
     - p2sh-exercise-1
     - p2sh-exercise-2

--- a/decoding/project.mdx
+++ b/decoding/project.mdx
@@ -6,12 +6,12 @@ draft: false
 category: Scripts
 layout: TopicBanner
 project: true
-bannerImage: /bitcoin-topics/static/images/topics/project-bitcoin-stack/stack-simulator.svg
+bannerImage: /decoding-bitcoin/static/images/topics/project-bitcoin-stack/stack-simulator.svg
 order: 405
 icon: "FaTools"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/project-stack-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/project-stack-thumbnail.webp"
     ]
 children:
     - setup-local-development
@@ -27,7 +27,7 @@ In this project, we'll build our very own Bitcoin Stack simulator!
 
 This project is a substantially larger and more in-depth challenge than the exercises we've seen throughout the course so far. This is a fantastic chance to review what we've learned. It's time to see how to use our newfound skills in a real-world context!
 
-<MinimalVideoPlayer src="/bitcoin-topics/static/images/topics/project-bitcoin-stack/bitcoin-stack3.mov" />
+<MinimalVideoPlayer src="/decoding-bitcoin/static/images/topics/project-bitcoin-stack/bitcoin-stack3.mov" />
 
 I'm so excited about this one. Let's get into it!
 

--- a/decoding/pushdata-opcodes.mdx
+++ b/decoding/pushdata-opcodes.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 6
-images: ["/bitcoin-topics/static/images/topics/thumbnails/data-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/data-thumbnail.webp"]
 parent: overview
 ---
 

--- a/decoding/quiz.mdx
+++ b/decoding/quiz.mdx
@@ -6,7 +6,7 @@ draft: false
 category: Scripts
 layout: TopicBanner
 order: 7
-images: ["/bitcoin-topics/static/images/topics/thumbnails/quiz-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/quiz-thumbnail.webp"]
 parent: overview
 ---
 

--- a/decoding/rbf.mdx
+++ b/decoding/rbf.mdx
@@ -7,7 +7,7 @@ category: Transactions
 layout: TopicBanner
 order: 3
 icon: "FaClipboardList"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/musig-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/musig-thumbnail.webp"]
 parent: "fee-calculation"
 ---
 

--- a/decoding/roadmap.mdx
+++ b/decoding/roadmap.mdx
@@ -9,7 +9,7 @@ order: 300
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-roadmap.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-roadmap.webp"
     ]
 ---
 
@@ -17,13 +17,13 @@ images:
     <div className="w-full">
         <div className="dark:hidden w-full rounded-lg">
             <SvgDisplay
-                src="/bitcoin-topics/static/images/topics/transactions/roadmap.svg"
+                src="/decoding-bitcoin/static/images/topics/transactions/roadmap.svg"
                 height="auto"
             />
         </div>
         <div className="hidden dark:block w-full rounded-lg">
             <SvgDisplay
-                src="/bitcoin-topics/static/images/topics/transactions/roadmap.svg"
+                src="/decoding-bitcoin/static/images/topics/transactions/roadmap.svg"
                 height="auto"
             />
         </div>

--- a/decoding/schnorr-signature.mdx
+++ b/decoding/schnorr-signature.mdx
@@ -9,7 +9,7 @@ order: 503
 icon: "FaHashtag"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/schnorr-signature-thumbnail.png"
+        "/decoding-bitcoin/static/images/topics/thumbnails/schnorr-signature-thumbnail.png"
     ]
 ---
 
@@ -29,14 +29,14 @@ We have two main characters to help us understand how Schnorr signatures work:
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-1-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-1-light.svg"
         width="80%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-1.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-1.svg"
         width="80%"
         height="auto"
     />
@@ -46,14 +46,14 @@ The interaction between Alice and Bob involves two key steps: **Signature Genera
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-2-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-2-light.svg"
         width="90%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-2.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-2.svg"
         width="90%"
         height="auto"
     />
@@ -73,13 +73,13 @@ Alice generates a private key `d`, then calculates her public key `P` by multipl
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-3-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-3-light.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-3.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-3.svg"
         height="auto"
     />
 </div>
@@ -122,13 +122,13 @@ _`k` is a scalar, `R` is a point on the elliptic curve._
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-4-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-4-light.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-4.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-4.svg"
         height="auto"
     />
 </div>
@@ -209,13 +209,13 @@ Alice sends both the message `m` and the signature `(R, s)` to Bob.
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-5-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-5-light.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-5.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-5.svg"
         height="auto"
     />
 </div>
@@ -330,13 +330,13 @@ To avoid this risk, BIP340 suggests a deterministic method for generating nonces
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-7-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-7-light.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-7.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-7.svg"
         height="auto"
     />
 </div>
@@ -454,13 +454,13 @@ Once Bob has confirmed that the equation holds, he can be fully assured that the
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-6-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-6-light.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/schnorr-sig-6.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/schnorr-sig-6.svg"
         height="auto"
     />
 </div>

--- a/decoding/script-parser.mdx
+++ b/decoding/script-parser.mdx
@@ -9,7 +9,7 @@ order: 6
 project: true
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/project-stack-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/project-stack-thumbnail.webp"
     ]
 parent: project
 ---

--- a/decoding/script-success-failure.mdx
+++ b/decoding/script-success-failure.mdx
@@ -8,7 +8,7 @@ layout: TopicBanner
 order: 4
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/script-success-failure-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/script-success-failure-thumbnail.webp"
     ]
 parent: overview
 ---
@@ -21,14 +21,14 @@ A valid script execution follows these rules:
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/valid-invalid-script.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/valid-invalid-script.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/dark-valid-invalid-script.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/dark-valid-invalid-script.svg"
         width="100%"
         height="auto"
     />
@@ -44,6 +44,6 @@ Any other outcome - early termination, an empty stack, or a "false" value on top
   expandable={false}
 >
 If you'd like to learn more about these type of errors you can check the [script_error.cpp](https://github.com/bitcoin/bitcoin/blob/master/src/script/script_error.cpp) file from bitcoin core source code 
-<MinimalVideoPlayer src="/bitcoin-topics/static/images/topics/overview/script_error.mov" autoPlay={false} />
+<MinimalVideoPlayer src="/decoding-bitcoin/static/images/topics/overview/script_error.mov" autoPlay={false} />
 
 </ExpandableAlert>

--- a/decoding/setup-local-development.mdx
+++ b/decoding/setup-local-development.mdx
@@ -9,7 +9,7 @@ order: 1
 project: true
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/project-stack-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/project-stack-thumbnail.webp"
     ]
 parent: project
 ---
@@ -23,7 +23,7 @@ If you're not familiar with Git, you can download a .zip file containing everyth
 
 <div className="relative w-full h-[400px] mb-32">
     <Image
-        src="/bitcoin-topics/static/images/topics/project-bitcoin-stack/repo-download.svg"
+        src="/decoding-bitcoin/static/images/topics/project-bitcoin-stack/repo-download.svg"
         alt="Purple toaster"
         layout="fill"
         objectFit="cover"
@@ -59,7 +59,7 @@ This will start a local development server. The terminal output should look some
     <div className="w-3/4 relative">
         <div className="absolute inset-0 bg-black opacity-5 filter blur-sm rounded-lg"></div>
         <Image
-            src="/bitcoin-topics/static/images/topics/project-bitcoin-stack/terminal.png"
+            src="/decoding-bitcoin/static/images/topics/project-bitcoin-stack/terminal.png"
             alt="Purple toaster"
             width={1200}
             height={675}
@@ -73,7 +73,7 @@ After downloading the project repository and starting a development server (npm 
 
 <div className="relative w-full aspect-[16/9] mb-16 mt-4">
     <Image
-        src="/bitcoin-topics/static/images/topics/project-bitcoin-stack/bitcoin-stack-app.png"
+        src="/decoding-bitcoin/static/images/topics/project-bitcoin-stack/bitcoin-stack-app.png"
         alt="Bitcoin Stack App initial page"
         layout="fill"
         objectFit="contain"

--- a/decoding/solution.mdx
+++ b/decoding/solution.mdx
@@ -9,7 +9,7 @@ order: 7
 project: true
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/project-stack-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/project-stack-thumbnail.webp"
     ]
 parent: project
 ---
@@ -26,7 +26,7 @@ The complete source code for this project is available on GitHub:
 
 <div className="relative w-full h-[400px] mb-8">
     <Image
-        src="/bitcoin-topics/static/images/topics/project-bitcoin-stack/repo-screenshot.png"
+        src="/decoding-bitcoin/static/images/topics/project-bitcoin-stack/repo-screenshot.png"
         alt="Bitcoin Script Playground Repository"
         layout="fill"
         objectFit="cover"
@@ -41,7 +41,7 @@ Here's a quick demonstration of the Bitcoin Script Playground in action:
 <video
     controls
     className="w-full h-auto rounded-lg shadow-lg"
-    src="/bitcoin-topics/static/images/topics/project-bitcoin-stack/bitcoin-stack3.mov"
+    src="/decoding-bitcoin/static/images/topics/project-bitcoin-stack/bitcoin-stack3.mov"
 >
     Your browser does not support the video tag.
 </video>

--- a/decoding/stack.mdx
+++ b/decoding/stack.mdx
@@ -8,7 +8,7 @@ layout: TopicBanner
 order: 1
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/bitcoin-stack-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/bitcoin-stack-thumbnail.webp"
     ]
 parent: overview
 ---

--- a/decoding/standard-nonstandard.mdx
+++ b/decoding/standard-nonstandard.mdx
@@ -8,7 +8,7 @@ layout: TopicBanner
 order: 5
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/standard-non-standard-tx-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/standard-non-standard-tx-thumbnail.webp"
     ]
 parent: overview
 ---
@@ -23,14 +23,14 @@ Below is a time line showing different output scripts types before and After Seg
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/segwit-timeline.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/segwit-timeline.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/dark-segwit-timeline.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/dark-segwit-timeline.svg"
         width="100%"
         height="auto"
     />
@@ -59,14 +59,14 @@ They are valid but are not relayed by most nodes for safety reasons
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/isStandard-check.svg"
+        src="/decoding-bitcoin/static/images/topics/overview/isStandard-check.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/overview/dark-isStandard-check.png"
+        src="/decoding-bitcoin/static/images/topics/overview/dark-isStandard-check.png"
         width="100%"
         height="auto"
     />

--- a/decoding/tagged-hashes.mdx
+++ b/decoding/tagged-hashes.mdx
@@ -9,7 +9,7 @@ order: 502
 icon: "FaHashtag"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/tagged-hashes-thumbnail.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/tagged-hashes-thumbnail.jpg"
     ]
 ---
 
@@ -29,14 +29,14 @@ Creating tagged hashes is straightforward and involves two steps:
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/tagged-hash-light.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/tagged-hash-light.svg"
         width="80%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/taproot/tagged-hash.svg"
+        src="/decoding-bitcoin/static/images/topics/taproot/tagged-hash.svg"
         width="80%"
         height="auto"
     />

--- a/decoding/taproot-roadmap.mdx
+++ b/decoding/taproot-roadmap.mdx
@@ -9,7 +9,7 @@ order: 501
 icon: "FaHashtag"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/taproot-roadmap-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/taproot-roadmap-thumbnail.webp"
     ]
 ---
 
@@ -17,13 +17,13 @@ images:
     <div className="w-full">
         <div className="dark:hidden w-full rounded-lg">
             <SvgDisplay
-                src="/bitcoin-topics/static/images/topics/taproot/taproot-roadmap.svg"
+                src="/decoding-bitcoin/static/images/topics/taproot/taproot-roadmap.svg"
                 height="auto"
             />
         </div>
         <div className="hidden dark:block w-full rounded-lg">
             <SvgDisplay
-                src="/bitcoin-topics/static/images/topics/taproot/taproot-roadmap.svg"
+                src="/decoding-bitcoin/static/images/topics/taproot/taproot-roadmap.svg"
                 height="auto"
             />
         </div>

--- a/decoding/technical-foundation.mdx
+++ b/decoding/technical-foundation.mdx
@@ -9,7 +9,7 @@ order: 304
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/taproot-roadmap-thumbnail.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/taproot-roadmap-thumbnail.webp"
     ]
 children:
     - endianness

--- a/decoding/transaction-creation.mdx
+++ b/decoding/transaction-creation.mdx
@@ -9,7 +9,7 @@ order: 305
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/creating-tx.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/creating-tx.webp"
     ]
 ---
 
@@ -18,14 +18,14 @@ To make this payment, she needs to create a Bitcoin transaction using the unspen
 
 <div className="dark:hidden w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/transaction1.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/transaction1.svg"
         width="80%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/transaction1.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/transaction1.svg"
         width="80%"
         height="auto"
     />
@@ -50,14 +50,14 @@ To create a transaction, Alice needs to specify which UTXOs she wants to use as 
 
 <div className="dark:hidden w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/transaction2.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/transaction2.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/transaction2.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/transaction2.svg"
         width="100%"
         height="auto"
     />
@@ -80,14 +80,14 @@ Each input in a Bitcoin transaction must include:
 
 <div className="dark:hidden w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/transaction3.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/transaction3.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/transaction3.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/transaction3.svg"
         width="100%"
         height="auto"
     />
@@ -102,14 +102,14 @@ For this transaction, Alice needs to create two outputs:
 
 <div className="dark:hidden w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/transaction4.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/transaction4.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/transaction4.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/transaction4.svg"
         width="100%"
         height="auto"
     />

--- a/decoding/transaction-lifecycle.mdx
+++ b/decoding/transaction-lifecycle.mdx
@@ -9,7 +9,7 @@ order: 301
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-lifecycle.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-lifecycle.webp"
     ]
 ---
 
@@ -18,22 +18,22 @@ Watch how a Bitcoin transaction moves through the network, from creation to conf
 <div className="full-width">
     <TransactionAnimationPlayer
         svgPaths={[
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/000.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/00.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/0.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/1.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/2.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/3.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/4.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/5.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/6.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/7.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/8.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/9.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/10.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/11.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/12.svg",
-            "/bitcoin-topics/static/images/topics/transactions/lifecycle/13.svg"
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/000.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/00.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/0.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/1.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/2.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/3.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/4.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/5.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/6.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/7.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/8.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/9.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/10.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/11.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/12.svg",
+            "/decoding-bitcoin/static/images/topics/transactions/lifecycle/13.svg"
         ]}
         svgId="esVE0LwtziS1"
     />

--- a/decoding/transaction-signing-00.mdx
+++ b/decoding/transaction-signing-00.mdx
@@ -9,7 +9,7 @@ order: 0
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-0.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-0.jpg"
     ]
 parent: "transaction-signing"
 ---
@@ -24,14 +24,14 @@ Inputs, outputs, and witness data will be added in the next steps.
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden full-width">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature6.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature6.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden full-width">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature6.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature6.svg"
         width="100%"
         height="auto"
     />

--- a/decoding/transaction-signing-01.mdx
+++ b/decoding/transaction-signing-01.mdx
@@ -9,7 +9,7 @@ order: 1
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-1.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-1.jpg"
     ]
 parent: "transaction-signing"
 ---
@@ -23,7 +23,7 @@ Each input in a Bitcoin transaction must specify:
 
 <div className="w-full rounded-xl overflow-hidden full-width">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature7.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature7.svg"
         width="100%"
         height="auto"
     />

--- a/decoding/transaction-signing-02.mdx
+++ b/decoding/transaction-signing-02.mdx
@@ -9,7 +9,7 @@ order: 2
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-2.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-2.jpg"
     ]
 parent: "transaction-signing"
 ---
@@ -21,7 +21,7 @@ Each output in a Bitcoin transaction requires:
 
 <div className="w-full rounded-xl overflow-hidden full-width">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature8.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature8.svg"
         width="100%"
         height="auto"
     />

--- a/decoding/transaction-signing-03.mdx
+++ b/decoding/transaction-signing-03.mdx
@@ -9,7 +9,7 @@ order: 3
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-3.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-3.jpg"
     ]
 parent: "transaction-signing"
 ---
@@ -20,7 +20,7 @@ This is different from legacy transactions where signatures are placed directly 
 
 <div className="w-full rounded-xl overflow-hidden full-width">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature9.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature9.svg"
         width="100%"
         height="auto"
     />
@@ -48,14 +48,14 @@ For our test vector:
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/siganture2.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/siganture2.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/siganture2.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/siganture2.svg"
         width="100%"
         height="auto"
     />

--- a/decoding/transaction-signing-04.mdx
+++ b/decoding/transaction-signing-04.mdx
@@ -9,14 +9,14 @@ order: 4
 icon: "FaFileSignature"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-4.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-4.jpg"
     ]
 parent: "transaction-signing"
 ---
 
 <div className="w-full rounded-xl overflow-hidden full-width">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature9.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature9.svg"
         width="100%"
         height="auto"
     />

--- a/decoding/transaction-signing-05.mdx
+++ b/decoding/transaction-signing-05.mdx
@@ -9,7 +9,7 @@ order: 5
 icon: "FaFileSignature"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-5.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-5.jpg"
     ]
 parent: "transaction-signing"
 ---

--- a/decoding/transaction-signing-06.mdx
+++ b/decoding/transaction-signing-06.mdx
@@ -9,7 +9,7 @@ order: 6
 icon: "FaFileSignature"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-6.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-6.jpg"
     ]
 parent: "transaction-signing"
 ---
@@ -216,14 +216,14 @@ This code cannot be run directly in the browser as Trinket doesn't support the E
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature3.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature3.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature3.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature3.png"
         width="100%"
         height="auto"
     />

--- a/decoding/transaction-signing-07.mdx
+++ b/decoding/transaction-signing-07.mdx
@@ -9,7 +9,7 @@ order: 7
 icon: "FaFileSignature"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-7.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-7.jpg"
     ]
 parent: "transaction-signing"
 ---
@@ -18,7 +18,7 @@ Our transaction now has all its fields populated except for the witness data.
 
 <div className="w-full rounded-xl overflow-hidden full-width">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature9.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature9.svg"
         width="100%"
         height="auto"
     />
@@ -136,14 +136,14 @@ This code cannot be run directly in the browser as Trinket doesn't support the E
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature4.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature4.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature4.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature4.png"
         width="100%"
         height="auto"
     />

--- a/decoding/transaction-signing-08.mdx
+++ b/decoding/transaction-signing-08.mdx
@@ -9,14 +9,14 @@ order: 8
 icon: "FaFileSignature"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-8.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-8.jpg"
     ]
 parent: "transaction-signing"
 ---
 
 <div className="w-full rounded-xl overflow-hidden full-width">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/signature10.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/signature10.svg"
         width="100%"
         height="auto"
     />
@@ -230,14 +230,14 @@ When we decode our final transaction using Bitcoin Core's `decoderawtransaction`
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/image.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/image.png"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/image.png"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/image.png"
         width="100%"
         height="auto"
     />

--- a/decoding/transaction-signing-09.mdx
+++ b/decoding/transaction-signing-09.mdx
@@ -9,7 +9,7 @@ order: 9
 icon: "FaFileSignature"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-9.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature-9.jpg"
     ]
 parent: "transaction-signing"
 ---

--- a/decoding/transaction-signing.mdx
+++ b/decoding/transaction-signing.mdx
@@ -9,7 +9,7 @@ order: 307
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature.jpg"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/signature/tx-thumbnail-signature.jpg"
     ]
 children:
     - transaction-signing-00
@@ -31,14 +31,14 @@ The first input is a legacy P2PK input which uses a different signing method tha
 
 <div className="dark:hidden w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/siganture1.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/siganture1.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-xl overflow-hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/signature/siganture1.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/signature/siganture1.svg"
         width="100%"
         height="auto"
     />

--- a/decoding/transaction-structure.mdx
+++ b/decoding/transaction-structure.mdx
@@ -9,7 +9,7 @@ order: 302
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-component.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-component.webp"
     ]
 children:
     - version

--- a/decoding/transaction-weight.mdx
+++ b/decoding/transaction-weight.mdx
@@ -7,7 +7,7 @@ category: Transactions
 layout: TopicBanner
 order: 1
 icon: "FaClipboardList"
-images: ["/bitcoin-topics/static/images/topics/thumbnails/musig-thumbnail.webp"]
+images: ["/decoding-bitcoin/static/images/topics/thumbnails/musig-thumbnail.webp"]
 parent: "fee-calculation"
 ---
 
@@ -29,13 +29,13 @@ For example, here's a raw transaction in hexadecimal:
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_8.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_8.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_8.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_8.svg"
         height="auto"
     />
 </div>
@@ -57,13 +57,13 @@ Where:
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_7.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_7.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_7.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_7.svg"
         height="auto"
     />
 </div>
@@ -87,13 +87,13 @@ SegWit achieves this by separating transaction data into two parts:
 
 <div className="dark:hidden">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_5.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_5.svg"
         height="auto"
     />
 </div>
 <div className="hidden dark:block">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/fees/fees_5.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/fees/fees_5.svg"
         height="auto"
     />
 </div>

--- a/decoding/utxo.mdx
+++ b/decoding/utxo.mdx
@@ -9,20 +9,20 @@ order: 303
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/utxo-accountmodel.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/utxo-accountmodel.webp"
     ]
 ---
 
 <div className="dark:hidden w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/utxo-accountModel.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/utxo-accountModel.svg"
         width="100%"
         height="auto"
     />
 </div>
 <div className="hidden dark:block w-full rounded-lg">
     <SvgDisplay
-        src="/bitcoin-topics/static/images/topics/transactions/utxo-accountModel.svg"
+        src="/decoding-bitcoin/static/images/topics/transactions/utxo-accountModel.svg"
         width="100%"
         height="auto"
     />

--- a/decoding/version.mdx
+++ b/decoding/version.mdx
@@ -9,7 +9,7 @@ order: 1
 icon: "FaClipboardList"
 images:
     [
-        "/bitcoin-topics/static/images/topics/thumbnails/transaction-module/tx-version.webp"
+        "/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-version.webp"
     ]
 parent: "transaction-structure"
 ---

--- a/decoding/welcome.mdx
+++ b/decoding/welcome.mdx
@@ -16,8 +16,8 @@ Welcome to Decoding Bitcoin, your go-to resource for understanding bitcoin, Priv
 <video
     controls
     className="w-full h-auto rounded-lg shadow-lg"
-    src="/bitcoin-topics/static/images/topics/decoding-bitcoin.mp4"
-    poster="/bitcoin-topics/static/images/topics/decoding-bitcoin-poster.png"
+    src="/decoding-bitcoin/static/images/topics/decoding-bitcoin.mp4"
+    poster="/decoding-bitcoin/static/images/topics/decoding-bitcoin-poster.png"
 >
     Your browser does not support the video tag.
 </video>


### PR DESCRIPTION
This PR updates references to the old repository name, changing `bitcoin-topics` to `decoding-bitcoin`.