### PR TITLE
Fix the order of pages under transaction structure

### DIFF
--- a/decoding/inputs-output-index.mdx
+++ b/decoding/inputs-output-index.mdx
@@ -5,7 +5,7 @@ lastmod: "2024-07-26"
 draft: false
 category: Transactions
 layout: TopicBanner
-order: 4
+order: 5
 icon: "FaClipboardList"
 images:
     [

--- a/decoding/inputs-scriptsig.mdx
+++ b/decoding/inputs-scriptsig.mdx
@@ -5,7 +5,7 @@ lastmod: "2024-07-26"
 draft: false
 category: Transactions
 layout: TopicBanner
-order: 6
+order: 7
 icon: "FaClipboardList"
 images:
     [

--- a/decoding/inputs-scriptsigsize.mdx
+++ b/decoding/inputs-scriptsigsize.mdx
@@ -5,7 +5,7 @@ lastmod: "2024-07-26"
 draft: false
 category: Transactions
 layout: TopicBanner
-order: 5
+order: 6
 icon: "FaClipboardList"
 images:
     [

--- a/decoding/inputs-sequence.mdx
+++ b/decoding/inputs-sequence.mdx
@@ -5,7 +5,7 @@ lastmod: "2024-07-26"
 draft: false
 category: Transactions
 layout: TopicBanner
-order: 6
+order: 8
 icon: "FaClipboardList"
 images: ["/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-thumbnail-sequence.jpg"]
 parent: "transaction-structure"

--- a/decoding/locktime.mdx
+++ b/decoding/locktime.mdx
@@ -5,7 +5,7 @@ lastmod: "2024-07-26"
 draft: false
 category: Transactions
 layout: TopicBanner
-order: 11
+order: 13
 icon: "FaClipboardList"
 images:
     [

--- a/decoding/outputs-amount.mdx
+++ b/decoding/outputs-amount.mdx
@@ -5,7 +5,7 @@ lastmod: "2024-07-26"
 draft: false
 category: Transactions
 layout: TopicBanner
-order: 8
+order: 10
 icon: "FaClipboardList"
 images:
     [

--- a/decoding/outputs-outputcount.mdx
+++ b/decoding/outputs-outputcount.mdx
@@ -5,7 +5,7 @@ lastmod: "2024-07-26"
 draft: false
 category: Transactions
 layout: TopicBanner
-order: 7
+order: 9
 icon: "FaClipboardList"
 images: ["/decoding-bitcoin/static/images/topics/thumbnails/transaction-module/tx-thumbnail-outputcount.jpg"]
 parent: "transaction-structure"

--- a/decoding/outputs-scriptpubkey-size.mdx
+++ b/decoding/outputs-scriptpubkey-size.mdx
@@ -5,7 +5,7 @@ lastmod: "2024-07-26"
 draft: false
 category: Transactions
 layout: TopicBanner
-order: 9
+order: 11
 icon: "FaClipboardList"
 images:
     [

--- a/decoding/outputs-scriptpubkey.mdx
+++ b/decoding/outputs-scriptpubkey.mdx
@@ -5,7 +5,7 @@ lastmod: "2024-07-26"
 draft: false
 category: Transactions
 layout: TopicBanner
-order: 10
+order: 12
 icon: "FaClipboardList"
 images:
     [


### PR DESCRIPTION
I noticed there was still an issue with the order of the pages under the transaction structure so fixed this:

![Screenshot 2025-02-12 at 4 02 44 PM](https://github.com/user-attachments/assets/c960139c-412e-48b9-b075-fb233a82cc77)
