### PR TITLE
Clarify hash lock description to emphasize preimage-hash matching

### DIFF
--- a/decoding/outputs-scriptpubkey.mdx
+++ b/decoding/outputs-scriptpubkey.mdx
@@ -85,7 +85,7 @@ The ScriptPubKey acts like a smart contract that defines how the bitcoins can be
 1. **Single Signature**: Requires one digital signature from a specific public key
 2. **Multi-signature**: Requires M-of-N signatures from a set of public keys
 3. **Time Locks**: Prevents spending until a certain time or block height
-4. **Hash Locks**: Requires revealing a preimage that hashes to a specific value
+4. **Hash Locks**: Requires revealing a preimage that matches a specific hash value
 
 <ExpandableAlert title="Warning" type="warning">
     An empty or invalid ScriptPubKey will make the output unspendable,


### PR DESCRIPTION
This commit updates the description of "Hash Locks" to improve technical accuracy and clarity. The previous phrasing:

    "Requires revealing a preimage that hashes to a specific value"

has been replaced with:

    "Requires revealing a preimage that matches a specific hash value"